### PR TITLE
ci(#10): add GitHub Actions workflow to run lint, build, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        node: [20]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint, build, and test
+        run: npm run ci
+
+      - name: Upload coverage (if present)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vitest-coverage
+          path: |
+            coverage
+          if-no-files-found: ignore
+

--- a/__tests__/deselection.spec.ts
+++ b/__tests__/deselection.spec.ts
@@ -1,0 +1,140 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock host SDK with spies for EventRouter.publish and resolveInteraction
+vi.mock("@renderx-plugins/host-sdk", () => ({
+  EventRouter: {
+    publish: vi.fn().mockResolvedValue(undefined),
+  },
+  resolveInteraction: (key: string) => {
+    if (key === "canvas.component.deselect") {
+      return { pluginId: "CanvasComponentPlugin", sequenceId: "canvas-component-deselect-symphony" };
+    }
+    if (key === "canvas.component.deselect.all") {
+      return { pluginId: "CanvasComponentPlugin", sequenceId: "canvas-component-deselect-all-symphony" };
+    }
+    return { pluginId: "noop", sequenceId: key } as any;
+  },
+  useConductor: () => ({ play: () => {} }),
+}));
+
+import { EventRouter } from "@renderx-plugins/host-sdk";
+import { handlers as deselectHandlers } from "../src/symphonies/deselect/deselect.stage-crew.ts";
+
+function ensureOverlays() {
+  const sel = document.getElementById("rx-selection-overlay") || document.createElement("div");
+  sel.id = "rx-selection-overlay";
+  document.body.appendChild(sel);
+  const adv = document.getElementById("rx-adv-line-overlay") || document.createElement("div");
+  adv.id = "rx-adv-line-overlay";
+  document.body.appendChild(adv);
+  return { sel: sel as HTMLDivElement, adv: adv as HTMLDivElement };
+}
+
+describe("Canvas component deselection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("publishes canvas.component.deselection.changed when publishDeselectionChanged is called", async () => {
+    const conductor = { play: vi.fn() };
+    const ctx = { conductor, baton: { id: "rx-node-abc" } };
+
+    await (deselectHandlers as any).publishDeselectionChanged({}, ctx);
+
+    expect(EventRouter.publish).toHaveBeenCalledWith(
+      "canvas.component.deselection.changed",
+      { id: "rx-node-abc" },
+      conductor
+    );
+  });
+
+  it("publishes canvas.component.selections.cleared when publishSelectionsCleared is called", async () => {
+    const conductor = { play: vi.fn() };
+    const ctx = { conductor };
+
+    await (deselectHandlers as any).publishSelectionsCleared({}, ctx);
+
+    expect(EventRouter.publish).toHaveBeenCalledWith(
+      "canvas.component.selections.cleared",
+      {},
+      conductor
+    );
+  });
+
+  it("hides overlays targeting the ID when deselectComponent is called and publishes topic", async () => {
+    const { sel, adv } = ensureOverlays();
+    sel.style.display = "block";
+    adv.style.display = "block";
+    sel.dataset.targetId = "rx-node-abc";
+    adv.dataset.targetId = "rx-node-abc";
+
+    const conductor = { play: vi.fn() };
+    const ctx = { conductor };
+
+    await (deselectHandlers as any).deselectComponent({ id: "rx-node-abc" }, ctx);
+
+    expect(sel.style.display).toBe("none");
+    expect(adv.style.display).toBe("none");
+
+    expect(EventRouter.publish).toHaveBeenCalledWith(
+      "canvas.component.deselection.changed",
+      { id: "rx-node-abc" },
+      conductor
+    );
+  });
+
+  it("clearAllSelections hides both overlays and clears dataset.targetId then publishes cleared topic", async () => {
+    const { sel, adv } = ensureOverlays();
+    sel.style.display = "block";
+    adv.style.display = "block";
+    sel.dataset.targetId = "rx-node-xyz";
+    adv.dataset.targetId = "rx-node-abc";
+
+    const conductor = { play: vi.fn() };
+    const ctx = { conductor };
+
+    await (deselectHandlers as any).clearAllSelections({}, ctx);
+
+    expect(sel.style.display).toBe("none");
+    expect(adv.style.display).toBe("none");
+    expect(sel.dataset.targetId || "").toBe("");
+    expect(adv.dataset.targetId || "").toBe("");
+
+    expect(EventRouter.publish).toHaveBeenCalledWith(
+      "canvas.component.selections.cleared",
+      {},
+      conductor
+    );
+  });
+
+  it("routeDeselectionRequest routes to deselect sequence when id is provided", async () => {
+    const play = vi.fn();
+    const conductor = { play };
+    const ctx = { conductor };
+
+    await (deselectHandlers as any).routeDeselectionRequest({ id: "rx-node-1" }, ctx);
+
+    expect(play).toHaveBeenCalledWith(
+      "CanvasComponentPlugin",
+      "canvas-component-deselect-symphony",
+      { id: "rx-node-1" }
+    );
+  });
+
+  it("routeDeselectionRequest routes to deselect-all sequence when no id provided", async () => {
+    const play = vi.fn();
+    const conductor = { play };
+    const ctx = { conductor };
+
+    await (deselectHandlers as any).routeDeselectionRequest({}, ctx);
+
+    expect(play).toHaveBeenCalledWith(
+      "CanvasComponentPlugin",
+      "canvas-component-deselect-all-symphony",
+      {}
+    );
+  });
+});
+

--- a/docs/canvas-component-deselection.md
+++ b/docs/canvas-component-deselection.md
@@ -1,0 +1,86 @@
+## Implementation Plan: Canvas Component Deselection
+
+### Current Architecture Analysis ✅
+The plugin currently has a robust selection system with:
+- Topic-first selection routing via `routeSelectionRequest`
+- Overlay management with `showSelectionOverlay` and `hideSelectionOverlay`
+- Event publishing for selection changes
+- JSON-based sequences for orchestration
+- Comprehensive test coverage for selection scenarios
+
+### Phase 1: Core Deselection Handlers
+
+**1. Create Deselect Stage-Crew Handlers**
+- `deselectComponent(data, ctx)`
+  - Hide overlays for the specified component ID. If the active overlay(s) target the given ID, hide them.
+  - Publish `canvas.component.deselection.changed` with `{ id }`.
+- `clearAllSelections(_data, ctx)`
+  - Call `hideAllOverlays()`.
+  - Publish `canvas.component.selections.cleared`.
+- `hideAllOverlays()`
+  - Hide both selection overlays: `#rx-selection-overlay` (standard) and `#rx-adv-line-overlay` (advanced line endpoints).
+  - Clear any `dataset.targetId` stored on these overlays to avoid stale state.
+
+> Note: We do not maintain a separate selection store in this package; selection model clearing is delegated to subscribers (e.g., Control Panel) via topics.
+
+**2. Create Deselection JSON Sequences**
+- `deselect.json` – Single component deselection sequence
+  - Beats: hide overlays for ID → publish deselection topic
+- `deselect-all.json` – Clear all selections sequence
+  - Beats: hide all overlays → publish selections cleared topic
+- Keep handlers kind/purity consistent with selection symphony (hide = stage-crew, publish = pure)
+
+### Phase 2: Event Integration
+
+**3. Add Deselection Event Routing (Topic-first)**
+- `routeDeselectionRequest(data, ctx)` – route `canvas.component.deselect.requested` (or equivalent) to the deselection sequence.
+- Add `deselect.requested.json` mirroring `select.requested.json`:
+  - Single beat: handler `routeDeselectionRequest` to play the appropriate sequence.
+- Support both single-ID and clear-all scenarios: if `data.id` is present, route to `canvas.component.deselect`; otherwise to `canvas.component.deselect.all`.
+
+**4. Update Main Plugin Exports**
+- Export new handlers from `src/index.ts` so JSON sequences can mount them:
+  - `routeDeselectionRequest`, `deselectComponent`, `clearAllSelections`, `hideAllOverlays`.
+
+### Phase 3: Testing & Topics
+
+**5. Create Comprehensive Tests (Vitest)**
+- Single component deselection:
+  - Hides `#rx-selection-overlay` and, when applicable, `#rx-adv-line-overlay` if they target the ID.
+  - Publishes `canvas.component.deselection.changed` with `{ id }`.
+- Clear all selections:
+  - Hides both overlays regardless of their current target.
+  - Publishes `canvas.component.selections.cleared`.
+- Routing:
+  - `routeDeselectionRequest` plays the correct sequence based on presence/absence of `data.id`.
+- Graceful behavior:
+  - No-throw when overlays are missing or conductor is absent.
+
+**6. Deselection Topic Publishing**
+- `canvas.component.deselection.changed` – single component deselected
+- `canvas.component.selections.cleared` – all selections cleared
+- Follow the existing `publishSelectionChanged` style: use `EventRouter.publish(..., ctx?.conductor)` and be tolerant of missing conductor.
+- Prefer topics over direct Control Panel sequence calls. There is no explicit Control Panel “hide” sequence in this repo; UI should subscribe to the deselection topics.
+
+### Phase 4: Integration
+
+**7. Update Plugin Manifest**
+- Add new sequences to `json-sequences/canvas-component/index.json`:
+  - `deselect.requested.json`, `deselect.json`, `deselect-all.json`
+- Ensure `handlersPath` points to `@renderx-plugins/canvas-component`.
+
+### Key Design Decisions
+
+1. Mirror selection architecture including topic-first request routing (adds `deselect.requested.json`).
+2. Use topic-based events for UI synchronization; avoid hard dependency on Control Panel sequences for deselection.
+3. Manage both overlay types (standard + advanced line) when deselecting.
+4. Maintain backward compatibility; do not alter selection behavior.
+5. Add comprehensive tests for new functionality.
+
+### Implementation Order
+1. Core handlers (Phase 1)
+2. Event routing + `deselect.requested.json` (Phase 2)
+3. Tests (Phase 3)
+4. Manifest updates (Phase 4)
+
+This plan ensures deselection integrates seamlessly with the existing selection system while adhering to the plugin’s architectural patterns and test coverage standards.

--- a/docs/what-needs-to-change-for-deselection.md
+++ b/docs/what-needs-to-change-for-deselection.md
@@ -1,0 +1,99 @@
+## Summary
+Deselection is topic-first. Your new sequences listen for a deselection “request” and then either deselect a single id or clear all. To make “clicking the blank canvas clears selection” work, the Host should publish the deselection request when the canvas background is clicked. The Canvas plugin should ensure background clicks reach the canvas (overlays don’t eat clicks) and may optionally provide a built-in fallback publisher.
+
+Below are targeted instructions for each repo/team.
+
+---
+
+## Host: renderx-plugins-demo (what to change)
+
+1) Ensure dependencies/sequences are registered
+- Update to the canvas-component version that contains deselection (the one from PR feat(#8)).
+- If your app auto-registers plugin sequences from each package’s index.json, no code change is needed. Otherwise, make sure the canvas-component sequences (including deselect.requested.json) are registered just like select.requested.json is.
+
+2) Publish the deselection request on blank-canvas clicks
+- Add a click listener on the canvas container (#rx-canvas), and when the click target is not inside a component (e.g., not within an element with class rx-comp or id rx-node-…), publish the topic canvas.component.deselect.requested with no id. That will route to deselect-all and clear overlays.
+
+Example wiring (Host-side):
+````ts mode=EXCERPT
+import { EventRouter } from "@renderx-plugins/host-sdk";
+
+function wireCanvasDeselect(canvas: HTMLElement, conductor: any) {
+  canvas.addEventListener("click", async (e: Event) => {
+    const target = e.target as HTMLElement;
+    const isComp = target.closest?.(".rx-comp,[id^='rx-node-']");
+    if (!isComp) await EventRouter.publish("canvas.component.deselect.requested", {}, conductor);
+  }, true);
+}
+````
+
+3) Optional: also clear selection on Escape
+- Many users expect ESC to clear selection; publish the same topic on keydown Escape.
+
+````ts mode=EXCERPT
+window.addEventListener("keydown", async (e) => {
+  if (e.key === "Escape") await EventRouter.publish("canvas.component.deselect.requested", {}, conductor);
+});
+````
+
+4) Keep click-to-select as-is
+- Your existing click-to-select should continue publishing canvas.component.select.requested with an id. The deselect handler only fires when there’s no component under the cursor.
+
+Acceptance check (Host):
+- Clicking a component still selects it.
+- Clicking empty canvas clears overlays and publishes canvas.component.selections.cleared (observable in logs/subscribers).
+- Pressing ESC clears selection (if you implement step 3).
+
+---
+
+## Canvas: renderx-plugin-canvas (what to change)
+
+The Canvas plugin can remain minimal and rely on the Host to publish deselection, but there are two recommended actions to ensure background clicks work reliably:
+
+1) Ensure overlays don’t block clicks to the canvas
+- The selection overlays should not consume pointer events; verify pointer-events: none for their containers so a click “through” overlays still reaches #rx-canvas.
+
+````css mode=EXCERPT
+#rx-selection-overlay,
+#rx-adv-line-overlay {
+  pointer-events: none; /* allow click-through for background deselect */
+}
+````
+
+2) Verify stable DOM IDs
+- Keep using:
+  - Canvas root: #rx-canvas
+  - Overlays: #rx-selection-overlay and #rx-adv-line-overlay
+- The deselection handlers in canvas-component hide these by ID.
+
+Optional fallback (Canvas plugin):
+- If you want a default behavior without depending on the Host, the Canvas plugin can publish deselection on background clicks on #rx-canvas. This is safe and won’t conflict with the Host; the topic just routes:
+
+````ts mode=EXCERPT
+import { EventRouter } from "@renderx-plugins/host-sdk";
+
+export function attachCanvasBackgroundDeselect(canvas: HTMLElement, conductor: any) {
+  canvas.addEventListener("click", async (e: Event) => {
+    const target = e.target as HTMLElement;
+    const isComp = target.closest?.(".rx-comp,[id^='rx-node-']");
+    if (!isComp) await EventRouter.publish("canvas.component.deselect.requested", {}, conductor);
+  }, true);
+}
+````
+
+Acceptance check (Canvas):
+- Overlays allow click-through; background clicks reach the canvas element.
+- No overlay element prevents propagation to the canvas background listener.
+
+---
+
+## How it flows end-to-end
+- Host publishes canvas.component.deselect.requested (no id) on a background click
+- canvas-component’s deselect.requested.json calls routeDeselectionRequest, which routes to “deselect-all”
+- The handlers hide #rx-selection-overlay and #rx-adv-line-overlay and publish:
+  - canvas.component.selections.cleared
+
+This mirrors the topic-first selection approach already in use, keeping responsibilities clean:
+- Host = interprets user intent (what was clicked)
+- Canvas plugin = presents the canvas DOM and ensures clicks can reach it
+- Canvas Component plugin = implements the selection/deselection orchestration and overlay lifecycle

--- a/json-sequences/canvas-component/deselect-all.json
+++ b/json-sequences/canvas-component/deselect-all.json
@@ -1,0 +1,16 @@
+{
+  "pluginId": "CanvasComponentDeselectionPlugin",
+  "id": "canvas-component-deselect-all-symphony",
+  "name": "Canvas Component Deselect All",
+  "movements": [
+    {
+      "id": "deselect-all",
+      "name": "Deselect All",
+      "beats": [
+        { "beat": 1, "event": "canvas:component:deselect:all", "title": "Hide All Overlays", "dynamics": "mf", "handler": "hideAllOverlays", "timing": "immediate", "kind": "stage-crew" },
+        { "beat": 2, "event": "canvas:component:selections:cleared", "title": "Publish Selections Cleared", "dynamics": "mf", "handler": "publishSelectionsCleared", "timing": "immediate", "kind": "pure" }
+      ]
+    }
+  ]
+}
+

--- a/json-sequences/canvas-component/deselect.json
+++ b/json-sequences/canvas-component/deselect.json
@@ -1,0 +1,16 @@
+{
+  "pluginId": "CanvasComponentDeselectionPlugin",
+  "id": "canvas-component-deselect-symphony",
+  "name": "Canvas Component Deselect",
+  "movements": [
+    {
+      "id": "deselect",
+      "name": "Deselect",
+      "beats": [
+        { "beat": 1, "event": "canvas:component:deselect", "title": "Hide Overlays for ID", "dynamics": "mf", "handler": "deselectComponent", "timing": "immediate", "kind": "stage-crew" },
+        { "beat": 2, "event": "canvas:component:deselection:changed", "title": "Publish Deselection Changed", "dynamics": "mf", "handler": "publishDeselectionChanged", "timing": "immediate", "kind": "pure" }
+      ]
+    }
+  ]
+}
+

--- a/json-sequences/canvas-component/deselect.requested.json
+++ b/json-sequences/canvas-component/deselect.requested.json
@@ -1,0 +1,23 @@
+{
+  "pluginId": "CanvasComponentDeselectionRequestPlugin",
+  "id": "canvas-component-deselect-requested-symphony",
+  "name": "Canvas Component Deselect Requested",
+  "movements": [
+    {
+      "id": "route-deselection",
+      "name": "Route Deselection",
+      "beats": [
+        {
+          "beat": 1,
+          "event": "canvas:component:deselect:route",
+          "title": "Route Deselection Request",
+          "dynamics": "mf",
+          "handler": "routeDeselectionRequest",
+          "timing": "immediate",
+          "kind": "pure"
+        }
+      ]
+    }
+  ]
+}
+

--- a/json-sequences/canvas-component/index.json
+++ b/json-sequences/canvas-component/index.json
@@ -18,6 +18,18 @@
       "handlersPath": "@renderx-plugins/canvas-component"
     },
     {
+      "file": "deselect.requested.json",
+      "handlersPath": "@renderx-plugins/canvas-component"
+    },
+    {
+      "file": "deselect.json",
+      "handlersPath": "@renderx-plugins/canvas-component"
+    },
+    {
+      "file": "deselect-all.json",
+      "handlersPath": "@renderx-plugins/canvas-component"
+    },
+    {
       "file": "drag.json",
       "handlersPath": "@renderx-plugins/canvas-component"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renderx-plugins/canvas-component",
-  "version": "0.1.0-rc.14",
+  "version": "0.1.0-rc.15",
   "publishConfig": {
     "access": "public"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { exportSvgToGif } from './symphonies/export/export.gif.stage-crew';
 import { exportSvgToMp4 } from './symphonies/export/export.mp4.stage-crew';
 import { updateSvgNodeAttribute } from './symphonies/update/update.svg-node.stage-crew';
 import { startLineManip, moveLineManip, endLineManip } from './symphonies/line-advanced/line.manip.stage-crew';
+import { hideAllOverlays, deselectComponent, publishDeselectionChanged, publishSelectionsCleared, routeDeselectionRequest as routeDeselectionRequestDeselection } from './symphonies/deselect/deselect.stage-crew';
 
 // Minimal merged handlers to support JSON-mounted sequences
 export const handlers = {
@@ -34,6 +35,12 @@ export const handlers = {
   routeSelectionRequest,
   notifyUiSelection,
   publishSelectionChanged,
+  // deselect
+  hideAllOverlays,
+  deselectComponent,
+  publishDeselectionChanged,
+  publishSelectionsCleared,
+  routeDeselectionRequest: routeDeselectionRequestDeselection,
   // drag
   updatePosition,
   forwardToControlPanel,

--- a/src/symphonies/deselect/deselect.stage-crew.ts
+++ b/src/symphonies/deselect/deselect.stage-crew.ts
@@ -1,0 +1,83 @@
+import { EventRouter, resolveInteraction, useConductor } from "@renderx-plugins/host-sdk";
+
+function hideOverlayById(id: string) {
+  const el = document.getElementById(id) as HTMLDivElement | null;
+  if (el) {
+    el.style.display = "none";
+  }
+  return el;
+}
+
+export function hideAllOverlays() {
+  try {
+    const sel = hideOverlayById("rx-selection-overlay");
+    const adv = hideOverlayById("rx-adv-line-overlay");
+    if (sel) delete (sel as any).dataset?.targetId;
+    if (adv) delete (adv as any).dataset?.targetId;
+  } catch {}
+}
+
+export async function deselectComponent(data: any, ctx: any) {
+  try {
+    const id = data?.id || ctx?.baton?.id || ctx?.baton?.elementId || ctx?.baton?.selectedId;
+    if (!id) return;
+
+    // Only hide overlays that are currently targeting this id
+    const sel = document.getElementById("rx-selection-overlay") as HTMLDivElement | null;
+    if (sel && sel.dataset?.targetId === String(id)) sel.style.display = "none";
+    const adv = document.getElementById("rx-adv-line-overlay") as HTMLDivElement | null;
+    if (adv && adv.dataset?.targetId === String(id)) adv.style.display = "none";
+
+    await publishDeselectionChanged({ id }, ctx);
+    return { id };
+  } catch {}
+}
+
+export async function publishDeselectionChanged(data: any, ctx: any) {
+  try {
+    const baton = ctx?.baton ?? data;
+    const id = data?.id || baton?.id || baton?.elementId || baton?.selectedId;
+    if (id) await EventRouter.publish("canvas.component.deselection.changed", { id: String(id) }, ctx?.conductor);
+  } catch {}
+}
+
+export async function publishSelectionsCleared(_data: any, ctx: any) {
+  try {
+    await EventRouter.publish("canvas.component.selections.cleared", {}, ctx?.conductor);
+  } catch {}
+}
+
+export async function clearAllSelections(_data: any, ctx: any) {
+  try {
+    hideAllOverlays();
+    await publishSelectionsCleared({}, ctx);
+  } catch {}
+}
+
+/**
+ * Topic-first deselection routing handler
+ * - If data.id is present route to canvas.component.deselect sequence
+ * - Otherwise route to canvas.component.deselect.all sequence
+ */
+export async function routeDeselectionRequest(data: any, ctx: any) {
+  try {
+    const hasId = !!data?.id;
+    const conductor = ctx?.conductor || useConductor() || (window as any).RenderX?.conductor;
+    if (!conductor?.play) return;
+
+    const key = hasId ? "canvas.component.deselect" : "canvas.component.deselect.all";
+    const r = resolveInteraction(key);
+    await conductor.play(r.pluginId, r.sequenceId, hasId ? { id: data.id } : {});
+  } catch {}
+}
+
+// Export handlers for JSON sequence mounting
+export const handlers = {
+  hideAllOverlays,
+  deselectComponent,
+  publishDeselectionChanged,
+  publishSelectionsCleared,
+  clearAllSelections,
+  routeDeselectionRequest,
+};
+


### PR DESCRIPTION
This PR adds a GitHub Actions CI workflow for this repo.

What it does:
- Triggers on push, pull_request to main, and manual workflow_dispatch
- Uses Node.js 20 on ubuntu-latest
- Caches npm dependencies
- Runs `npm ci` then `npm run ci` (lint, build, tests)
- Uploads coverage folder as an artifact if present
- Uses concurrency to cancel in-progress runs per ref

Benefits:
- Fast feedback on lint/build/test status for all PRs and pushes
- Simple config; can expand the matrix (OS/Node versions) later if needed

Closes #10.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author