### PR TITLE
feat(#12): implement topic-first delete operation (handlers, sequences, routing, tests)

### DIFF
--- a/__tests__/delete.spec.ts
+++ b/__tests__/delete.spec.ts
@@ -1,0 +1,113 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock host SDK with spies for EventRouter.publish and resolveInteraction
+vi.mock("@renderx-plugins/host-sdk", () => ({
+  EventRouter: {
+    publish: vi.fn().mockResolvedValue(undefined),
+  },
+  resolveInteraction: (key: string) => {
+    if (key === "canvas.component.delete") {
+      return { pluginId: "CanvasComponentDeletePlugin", sequenceId: "canvas-component-delete-symphony" };
+    }
+    return { pluginId: "noop", sequenceId: key } as any;
+  },
+  useConductor: () => ({ play: () => {} }),
+}));
+
+import { EventRouter } from "@renderx-plugins/host-sdk";
+import { handlers as deleteHandlers } from "../src/symphonies/delete/delete.stage-crew.ts";
+
+function ensureOverlays() {
+  const sel = document.getElementById("rx-selection-overlay") || document.createElement("div");
+  sel.id = "rx-selection-overlay";
+  document.body.appendChild(sel);
+  const adv = document.getElementById("rx-adv-line-overlay") || document.createElement("div");
+  adv.id = "rx-adv-line-overlay";
+  document.body.appendChild(adv);
+  return { sel: sel as HTMLDivElement, adv: adv as HTMLDivElement };
+}
+
+function ensureComponent(id: string) {
+  const el = document.createElement("div");
+  el.id = id;
+  el.className = "rx-comp";
+  document.body.appendChild(el);
+  return el;
+}
+
+describe("Canvas component delete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("publishes canvas.component.deleted when publishDeleted is called", async () => {
+    const conductor = { play: vi.fn() };
+    const ctx = { conductor, baton: { id: "rx-node-abc" } } as any;
+
+    await (deleteHandlers as any).publishDeleted({}, ctx);
+
+    expect(EventRouter.publish).toHaveBeenCalledWith(
+      "canvas.component.deleted",
+      { id: "rx-node-abc" },
+      conductor
+    );
+  });
+
+  it("removes element, hides overlays, and publishes topic when deleteComponent is called", async () => {
+    const { sel, adv } = ensureOverlays();
+    sel.style.display = "block";
+    adv.style.display = "block";
+    ensureComponent("rx-node-abc");
+    sel.dataset.targetId = "rx-node-abc";
+    adv.dataset.targetId = "rx-node-abc";
+
+    const conductor = { play: vi.fn() };
+    const ctx = { conductor } as any;
+
+    await (deleteHandlers as any).deleteComponent({ id: "rx-node-abc" }, ctx);
+
+    expect(document.getElementById("rx-node-abc")).toBeNull();
+    expect(sel.style.display).toBe("none");
+    expect(adv.style.display).toBe("none");
+
+    expect(EventRouter.publish).toHaveBeenCalledWith(
+      "canvas.component.deleted",
+      { id: "rx-node-abc" },
+      conductor
+    );
+  });
+
+  it("routeDeleteRequest plays delete sequence with provided id", async () => {
+    const play = vi.fn();
+    const conductor = { play };
+    const ctx = { conductor } as any;
+
+    await (deleteHandlers as any).routeDeleteRequest({ id: "rx-node-1" }, ctx);
+
+    expect(play).toHaveBeenCalledWith(
+      "CanvasComponentDeletePlugin",
+      "canvas-component-delete-symphony",
+      { id: "rx-node-1" }
+    );
+  });
+
+  it("routeDeleteRequest derives id from overlay when not provided", async () => {
+    const { sel } = ensureOverlays();
+    sel.dataset.targetId = "rx-node-xyz";
+
+    const play = vi.fn();
+    const conductor = { play };
+    const ctx = { conductor } as any;
+
+    await (deleteHandlers as any).routeDeleteRequest({}, ctx);
+
+    expect(play).toHaveBeenCalledWith(
+      "CanvasComponentDeletePlugin",
+      "canvas-component-delete-symphony",
+      { id: "rx-node-xyz" }
+    );
+  });
+});
+

--- a/json-sequences/canvas-component/delete.json
+++ b/json-sequences/canvas-component/delete.json
@@ -1,0 +1,16 @@
+{
+  "pluginId": "CanvasComponentDeletePlugin",
+  "id": "canvas-component-delete-symphony",
+  "name": "Canvas Component Delete",
+  "movements": [
+    {
+      "id": "delete",
+      "name": "Delete",
+      "beats": [
+        { "beat": 1, "event": "canvas:component:delete", "title": "Delete Component", "dynamics": "mf", "handler": "deleteComponent", "timing": "immediate", "kind": "stage-crew" },
+        { "beat": 2, "event": "canvas:component:deleted", "title": "Publish Deleted", "dynamics": "mf", "handler": "publishDeleted", "timing": "immediate", "kind": "pure" }
+      ]
+    }
+  ]
+}
+

--- a/json-sequences/canvas-component/delete.requested.json
+++ b/json-sequences/canvas-component/delete.requested.json
@@ -1,0 +1,15 @@
+{
+  "pluginId": "CanvasComponentDeleteRequestPlugin",
+  "id": "canvas-component-delete-requested-symphony",
+  "name": "Canvas Component Delete Requested",
+  "movements": [
+    {
+      "id": "route-delete",
+      "name": "Route Delete",
+      "beats": [
+        { "beat": 1, "event": "canvas:component:delete:route", "title": "Route Delete Request", "dynamics": "mf", "handler": "routeDeleteRequest", "timing": "immediate", "kind": "pure" }
+      ]
+    }
+  ]
+}
+

--- a/json-sequences/canvas-component/index.json
+++ b/json-sequences/canvas-component/index.json
@@ -30,6 +30,14 @@
       "handlersPath": "@renderx-plugins/canvas-component"
     },
     {
+      "file": "delete.requested.json",
+      "handlersPath": "@renderx-plugins/canvas-component"
+    },
+    {
+      "file": "delete.json",
+      "handlersPath": "@renderx-plugins/canvas-component"
+    },
+    {
       "file": "drag.json",
       "handlersPath": "@renderx-plugins/canvas-component"
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { exportSvgToMp4 } from './symphonies/export/export.mp4.stage-crew';
 import { updateSvgNodeAttribute } from './symphonies/update/update.svg-node.stage-crew';
 import { startLineManip, moveLineManip, endLineManip } from './symphonies/line-advanced/line.manip.stage-crew';
 import { hideAllOverlays, deselectComponent, publishDeselectionChanged, publishSelectionsCleared, routeDeselectionRequest as routeDeselectionRequestDeselection } from './symphonies/deselect/deselect.stage-crew';
+import { deleteComponent, publishDeleted, routeDeleteRequest as routeDeleteRequestDelete } from './symphonies/delete/delete.stage-crew';
 
 // Minimal merged handlers to support JSON-mounted sequences
 export const handlers = {
@@ -41,6 +42,10 @@ export const handlers = {
   publishDeselectionChanged,
   publishSelectionsCleared,
   routeDeselectionRequest: routeDeselectionRequestDeselection,
+  // delete
+  deleteComponent,
+  publishDeleted,
+  routeDeleteRequest: routeDeleteRequestDelete,
   // drag
   updatePosition,
   forwardToControlPanel,

--- a/src/symphonies/delete/delete.stage-crew.ts
+++ b/src/symphonies/delete/delete.stage-crew.ts
@@ -1,0 +1,63 @@
+import { EventRouter, resolveInteraction, useConductor } from "@renderx-plugins/host-sdk";
+
+function resolveId(data: any, ctx: any): string | undefined {
+  const fromData = data?.id;
+  const fromBaton = ctx?.baton?.id || ctx?.baton?.elementId || ctx?.baton?.selectedId;
+  if (fromData) return String(fromData);
+  if (fromBaton) return String(fromBaton);
+  // Fallback: current selection overlay target
+  const sel = document.getElementById("rx-selection-overlay") as HTMLDivElement | null;
+  const overlayId = sel?.dataset?.targetId;
+  return overlayId ? String(overlayId) : undefined;
+}
+
+export async function publishDeleted(data: any, ctx: any) {
+  try {
+    const id = resolveId(data, ctx);
+    if (!id) return;
+    await EventRouter.publish("canvas.component.deleted", { id }, ctx?.conductor);
+  } catch {}
+}
+
+function hideOverlaysForId(id: string) {
+  try {
+    const sel = document.getElementById("rx-selection-overlay") as HTMLDivElement | null;
+    if (sel && sel.dataset?.targetId === String(id)) sel.style.display = "none";
+    const adv = document.getElementById("rx-adv-line-overlay") as HTMLDivElement | null;
+    if (adv && adv.dataset?.targetId === String(id)) adv.style.display = "none";
+  } catch {}
+}
+
+export async function deleteComponent(data: any, ctx: any) {
+  try {
+    const id = resolveId(data, ctx);
+    if (!id) return;
+
+    const el = document.getElementById(String(id));
+    if (el && el.parentElement) {
+      el.parentElement.removeChild(el);
+    }
+
+    hideOverlaysForId(String(id));
+    await publishDeleted({ id }, ctx);
+    return { id };
+  } catch {}
+}
+
+export async function routeDeleteRequest(data: any, ctx: any) {
+  try {
+    const id = resolveId(data, ctx);
+    if (!id) return;
+
+    const conductor = ctx?.conductor || useConductor() || (window as any)?.RenderX?.conductor;
+    if (!conductor?.play) return;
+
+    const r = resolveInteraction("canvas.component.delete");
+    if (!r?.pluginId || !r?.sequenceId) return;
+
+    await conductor.play(r.pluginId, r.sequenceId, { id });
+  } catch {}
+}
+
+export const handlers = { deleteComponent, publishDeleted, routeDeleteRequest };
+


### PR DESCRIPTION
Implements a topic-first Delete operation for canvas components.

What’s included:
- Handlers (src/symphonies/delete/delete.stage-crew.ts):
  - deleteComponent: removes element by id and hides overlays if targeting that id
  - publishDeleted: publishes `canvas.component.deleted`
  - routeDeleteRequest: routes the delete.requested topic to the delete sequence, deriving id from data/baton/overlay
- Sequences:
  - json-sequences/canvas-component/delete.requested.json (routing)
  - json-sequences/canvas-component/delete.json (delete + publish)
- Index update to register sequences
- Tests: __tests__/delete.spec.ts (TDD)

How host should wire:
- On Delete key press, publish `canvas.component.delete.requested` with the selected id when possible; if not, the router will attempt to derive id from overlays.
- Add an interaction mapping for `canvas.component.delete` → CanvasComponentDeletePlugin/canvas-component-delete-symphony.

All tests pass locally via `npm run ci`.

Closes #12.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author