### PR TITLE
fix(#14): align pluginId across 9 canvas-component sequences

### DIFF
--- a/json-sequences/canvas-component/resize.line.end.json
+++ b/json-sequences/canvas-component/resize.line.end.json
@@ -1,5 +1,5 @@
 {
-  "pluginId": "CanvasLineResizeEndPlugin",
+  "pluginId": "CanvasComponentPlugin",
   "id": "canvas-line-resize-end-symphony",
   "name": "Canvas Line Resize End",
   "movements": [

--- a/json-sequences/canvas-component/resize.line.move.json
+++ b/json-sequences/canvas-component/resize.line.move.json
@@ -1,5 +1,5 @@
 {
-  "pluginId": "CanvasLineResizeMovePlugin",
+  "pluginId": "CanvasComponentPlugin",
   "id": "canvas-line-resize-move-symphony",
   "name": "Canvas Line Resize Move",
   "movements": [

--- a/json-sequences/canvas-component/resize.line.start.json
+++ b/json-sequences/canvas-component/resize.line.start.json
@@ -1,5 +1,5 @@
 {
-  "pluginId": "CanvasLineResizeStartPlugin",
+  "pluginId": "CanvasComponentPlugin",
   "id": "canvas-line-resize-start-symphony",
   "name": "Canvas Line Resize Start",
   "movements": [

--- a/json-sequences/canvas-component/resize.move.json
+++ b/json-sequences/canvas-component/resize.move.json
@@ -1,5 +1,5 @@
 {
-  "pluginId": "CanvasComponentResizeMovePlugin",
+  "pluginId": "CanvasComponentPlugin",
   "id": "canvas-component-resize-move-symphony",
   "name": "Canvas Component Resize Move",
   "movements": [

--- a/json-sequences/canvas-component/resize.start.json
+++ b/json-sequences/canvas-component/resize.start.json
@@ -1,5 +1,5 @@
 {
-  "pluginId": "CanvasComponentResizeStartPlugin",
+  "pluginId": "CanvasComponentPlugin",
   "id": "canvas-component-resize-start-symphony",
   "name": "Canvas Component Resize Start",
   "movements": [

--- a/json-sequences/canvas-component/select.json
+++ b/json-sequences/canvas-component/select.json
@@ -1,5 +1,5 @@
 {
-  "pluginId": "CanvasComponentSelectionPlugin",
+  "pluginId": "CanvasComponentPlugin",
   "id": "canvas-component-select-symphony",
   "name": "Canvas Component Select",
   "movements": [

--- a/json-sequences/canvas-component/select.requested.json
+++ b/json-sequences/canvas-component/select.requested.json
@@ -1,5 +1,5 @@
 {
-  "pluginId": "CanvasComponentSelectionRequestPlugin",
+  "pluginId": "CanvasComponentPlugin",
   "id": "canvas-component-select-requested-symphony",
   "name": "Canvas Component Select Requested",
   "movements": [

--- a/json-sequences/canvas-component/select.svg-node.json
+++ b/json-sequences/canvas-component/select.svg-node.json
@@ -1,5 +1,5 @@
 {
-  "pluginId": "CanvasComponentSvgNodeSelectionPlugin",
+  "pluginId": "CanvasComponentPlugin",
   "id": "canvas-component-select-svg-node-symphony",
   "name": "Canvas Component Select SVG Node",
   "movements": [

--- a/json-sequences/canvas-component/update.svg-node.json
+++ b/json-sequences/canvas-component/update.svg-node.json
@@ -1,5 +1,5 @@
 {
-  "pluginId": "CanvasComponentSvgNodeUpdatePlugin",
+  "pluginId": "CanvasComponentPlugin",
   "id": "canvas-component-update-svg-node-symphony",
   "name": "Canvas Component Update SVG Node",
   "movements": [


### PR DESCRIPTION
This PR aligns the pluginId across the nine canvas-component sequences with the manifest-defined CanvasComponentPlugin.

- Updates the following files to set "pluginId": "CanvasComponentPlugin":
  - json-sequences/canvas-component/resize.line.end.json
  - json-sequences/canvas-component/resize.line.move.json
  - json-sequences/canvas-component/resize.line.start.json
  - json-sequences/canvas-component/resize.move.json
  - json-sequences/canvas-component/resize.start.json
  - json-sequences/canvas-component/select.json
  - json-sequences/canvas-component/select.requested.json
  - json-sequences/canvas-component/select.svg-node.json
  - json-sequences/canvas-component/update.svg-node.json

Why:
- Keeps sequences consistent with package.json renderx.plugins entry
- Unblocks/keeps passing the plugin loader consistency guardrails

Validation:
- Ran `npm run test`: all tests pass locally

Closes #14

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author