### PR TITLE
fix: prevent selection routing loop by adding guard and regression tests

### DIFF
--- a/__tests__/selection-topic-first.spec.ts
+++ b/__tests__/selection-topic-first.spec.ts
@@ -59,7 +59,7 @@ describe("Topic-first selection approach", () => {
       expect(mockConductor.play).toHaveBeenCalledWith(
         "CanvasComponentPlugin",
         "canvas-component-select-symphony",
-        { id: "rx-node-button123" }
+        { id: "rx-node-button123", _routed: true }
       );
     });
 
@@ -156,7 +156,7 @@ describe("Topic-first selection approach", () => {
       expect(mockConductor.play).toHaveBeenCalledWith(
         "CanvasComponentPlugin",
         "canvas-component-select-symphony",
-        { id: "rx-node-button123" }
+        { id: "rx-node-button123", _routed: true }
       );
 
       // Step 3: Selection sequence runs with guaranteed ID

--- a/__tests__/selection.loop-regression.spec.ts
+++ b/__tests__/selection.loop-regression.spec.ts
@@ -1,0 +1,78 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock host SDK
+vi.mock("@renderx-plugins/host-sdk", () => ({
+  EventRouter: {
+    publish: vi.fn().mockResolvedValue(undefined),
+  },
+  resolveInteraction: (key: string) => {
+    if (key === "canvas.component.select") {
+      return {
+        pluginId: "CanvasComponentPlugin",
+        sequenceId: "canvas-component-select-symphony",
+      } as any;
+    }
+    if (key === "control.panel.selection.show") {
+      return {
+        pluginId: "ControlPanelPlugin",
+        sequenceId: "control-panel-selection-show-symphony",
+      } as any;
+    }
+    return { pluginId: "noop", sequenceId: key } as any;
+  },
+  isFlagEnabled: () => false,
+  useConductor: () => ({ play: vi.fn() }),
+}));
+
+import { handlers as selectHandlers } from "../src/symphonies/select/select.stage-crew.ts";
+import { EventRouter } from "@renderx-plugins/host-sdk";
+
+describe("Selection routing loop regression", () => {
+  let mockConductor: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = `<div id="rx-canvas"></div>`;
+    mockConductor = { play: vi.fn().mockResolvedValue(undefined) };
+  });
+
+  it("routeSelectionRequest should not re-route when _routed is true", async () => {
+    const data = { id: "rx-node-button123", _routed: true };
+    const ctx = { conductor: mockConductor };
+
+    await selectHandlers.routeSelectionRequest(data, ctx);
+
+    expect(mockConductor.play).not.toHaveBeenCalled();
+  });
+
+  it("routeSelectionRequest should not publish any request topics", async () => {
+    const data = { id: "rx-node-button123" };
+    const ctx = { conductor: mockConductor };
+
+    await selectHandlers.routeSelectionRequest(data, ctx);
+
+    // Router only plays the selection sequence; it should not publish topics
+    expect(EventRouter.publish).not.toHaveBeenCalled();
+  });
+
+  it("publishSelectionChanged publishes selection.changed and not select.requested", async () => {
+    const data = { id: "rx-node-container456" };
+    const ctx = { conductor: mockConductor };
+
+    await selectHandlers.publishSelectionChanged(data, ctx);
+
+    // Ensure no request topic was published
+    const calls = (EventRouter.publish as any).mock.calls as any[];
+    const requestedCalls = calls.filter((c) => String(c?.[0] || "").includes("canvas.component.select.requested"));
+    expect(requestedCalls.length).toBe(0);
+
+    // Ensure selection.changed was published once
+    expect(EventRouter.publish).toHaveBeenCalledWith(
+      "canvas.component.selection.changed",
+      { id: "rx-node-container456" },
+      mockConductor
+    );
+  });
+});
+

--- a/src/symphonies/select/select.stage-crew.ts
+++ b/src/symphonies/select/select.stage-crew.ts
@@ -13,6 +13,9 @@ import {
  */
 export async function routeSelectionRequest(data: any, ctx: any) {
   try {
+    // Guard against accidental re-entry loops
+    if (data?._routed === true) return;
+
     const id = data?.id;
     if (!id) return;
 
@@ -23,9 +26,9 @@ export async function routeSelectionRequest(data: any, ctx: any) {
       return;
     }
 
-    // Route to the selection sequence with the ID
+    // Route to the selection sequence with the ID and mark as routed
     const r = resolveInteraction("canvas.component.select");
-    await conductor.play(r.pluginId, r.sequenceId, { id });
+    await conductor.play(r.pluginId, r.sequenceId, { id, _routed: true });
   } catch (error) {
     // Gracefully handle routing errors
     ctx.logger?.warn?.("Selection routing error:", error);


### PR DESCRIPTION
Fixes #16

This PR addresses an infinite loop in canvas selection routing by adding a defensive loop guard and tests.

Changes:
- Add `_routed` loop guard to `routeSelectionRequest` to prevent re-entry
- Ensure routed payload includes `{ _routed: true }`
- Add `selection.loop-regression.spec.ts` to cover loop prevention and topic publishing behavior
- Update `selection-topic-first.spec.ts` expectations to reflect the `_routed` flag

Verification:
- All tests pass locally via `npm test` (149 passed, 13 skipped)

Notes:
- Handler already routes to `canvas.component.select` (correct flow); guard is defense-in-depth in case external systems re-emit `*.select.requested`.
- Logging via `ctx.logger` maintained.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author